### PR TITLE
Fix issue with Pimcore's "Login as this user in a different browser" functionality

### DIFF
--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -104,6 +104,11 @@ class LoginListener
     {
         //Get credentials from the login event
         $credentials = $event->getCredentials();
+        
+        if(isset($credentials['token'])) {
+            return;
+        }
+        
         $username = $credentials['username'];
         $password = $credentials['password'];
 


### PR DESCRIPTION
Currently when using this bundle Pimcore's "Login as this user in a different browser" functionality does not work. With this pull request the bundle will check if the current authentication is via token - and if so, skip the ldap auth.