### PR TITLE
Only check user full path exclude if user exists

### DIFF
--- a/src/Service/Ldap.php
+++ b/src/Service/Ldap.php
@@ -130,7 +130,7 @@ class Ldap
 
             foreach ($this->excludeRules['users'] as $userExcludeRule) {
                 if (@preg_match($userExcludeRule, null) !== false) { //Check as regex (@ sign in front of the regex function is to prevent warnings on the valid regex test)
-                    if (preg_match($userExcludeRule, $username)  || preg_match($userExcludeRule, $userFullPath)) {
+                    if (preg_match($userExcludeRule, $username)  || ($userFullPath && preg_match($userExcludeRule, $userFullPath))) {
                         $this->logger->debug(sprintf("User '%s' excluded by the exclude by user rule '%s'", $username, $userExcludeRule));
                         return true;
                     }

--- a/tests/Service/LdapTest.php
+++ b/tests/Service/LdapTest.php
@@ -72,6 +72,37 @@ class LdapTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
+    public function testIsUserExcludedByUsernameWithNegativeRegex() {
+        $this->ldap = $this->getMockBuilder(Ldap::class)
+            ->setConstructorArgs(array(
+                $this->symfonyLdap,
+                'dc=example,dc=com',
+                '',
+                '',
+                '',
+                'sAMAccountName',
+                '({uid_key}={username})',
+                array(
+                    'users' => ['admin', '/^((?!example\.org).)*$/i']
+                ),
+                new DefaultLdapUserMapper(),
+                $this->createMock(LoggerInterface::class)
+            ))
+            ->setMethods(array(
+                'getLdapUser',
+                'getUserRoleNames',
+                'getPimcoreUserByUsername',
+                'getPimcoreUserFolderById',
+                'getPimcoreUserRoleById',
+                'getPimcoreUserRoleByName',
+                'getDefaultRolesIds',
+            ))
+            ->getMock();
+
+        $this->assertTrue($this->ldap->isUserExcluded('test'));
+        $this->assertFalse($this->ldap->isUserExcluded('test@example.org'));
+    }
+
     public function providerIsUserExcludedByUser()
     {
         return array(

--- a/tests/Service/LdapTest.php
+++ b/tests/Service/LdapTest.php
@@ -72,6 +72,17 @@ class LdapTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
+    public function providerIsUserExcludedByUser()
+    {
+        return array(
+            array('admin', true),
+            array('noldap_test', true),
+            array('administrator', false),
+            array('test_username', false),
+            array('test_noldap', false),
+        );
+    }
+
     public function testIsUserExcludedByUsernameWithNegativeRegex() {
         $this->ldap = $this->getMockBuilder(Ldap::class)
             ->setConstructorArgs(array(
@@ -101,17 +112,6 @@ class LdapTest extends TestCase
 
         $this->assertTrue($this->ldap->isUserExcluded('test'));
         $this->assertFalse($this->ldap->isUserExcluded('test@example.org'));
-    }
-
-    public function providerIsUserExcludedByUser()
-    {
-        return array(
-            array('admin', true),
-            array('noldap_test', true),
-            array('administrator', false),
-            array('test_username', false),
-            array('test_noldap', false),
-        );
     }
 
     /**


### PR DESCRIPTION
Without this change it is not possible to exclude users which do not have a certain string in their user name.
For example we had the following in our config.yml:
```yaml
alep_ldap:
  exclude: ['/^((?!example\.org).)*$/i']
```
to only use LDAP authentication for users which have example.org in their username (or in other words: exclude those which do not have example.org in their user name). Sadly this does not work when the user does not exist as in this case in https://github.com/alexpozzi/pimcore-ldap-bundle/blob/a2c42ce77e8d1b61841131962ed0c9af87f2a7f9/src/Service/Ldap.php#L133 `$userFullPath` is empty - and so this negative regex will always match and LDAP authentication does not get tried - although the user might have a valid LDAP login.