### PR TITLE
[BUGFIX] use correct name in composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pimcore >= 5.1.0
 
 ## Installation
 
-1) Install the bundle using composer `composer require alep/ldap-bundle`.
+1) Install the bundle using composer `composer require blackbit_digital_commerce/pimcore-ldap`.
 2) Open Pimcore Admin UI, navigate to `Tools` > `Extensions` and activate the bundle.
 
 


### PR DESCRIPTION
Changed the name in the installation part for composer to the corresponding name in composer.json.